### PR TITLE
[issue#49] fixed bug and updated specs

### DIFF
--- a/lib/job_tomate/values/github/status.rb
+++ b/lib/job_tomate/values/github/status.rb
@@ -26,12 +26,8 @@ module JobTomate
           @data = data.slice(*STORED_DATA_ATTRIBUTES)
         end
 
-        def author_github_user
-          data["commit"]["author"]["login"]
-        end
-
-        def author_user
-          JobTomate::Data::User.where(github_user: author_github_user).first
+        def author_github_login
+          data.dig("commit", "author", "login")
         end
 
         def branch

--- a/spec/acceptance/github/status_spec.rb
+++ b/spec/acceptance/github/status_spec.rb
@@ -33,12 +33,23 @@ describe "/webhooks/github" do
       expect(stub).to have_been_requested
     end
 
-    context "received status update is filtered" do
+    context "status update is filtered" do
       it "does not notify the status update author" do
         receive_stored_webhook(:github_status_update) do |webhook|
           source = "Your tests passed on CircleCI!"
           replacement = "Code Climate is analyzing this code"
           webhook.body.gsub!(source, replacement)
+        end
+        expect(stub).not_to have_been_requested
+      end
+    end
+
+    context "status has no author login" do
+      it "does nothing" do
+        receive_stored_webhook(:github_status_update) do |webhook|
+          body = webhook.value.parsed_body
+          body["commit"]["author"] = nil
+          webhook.body = body.to_json
         end
         expect(stub).not_to have_been_requested
       end


### PR DESCRIPTION
Sometimes, the status payload does not have a `commit.author` value. Ignoring the event in this case.

Fixes #49 