### PR TITLE
[issue#63] added command to get JIRA fields

### DIFF
--- a/doc/development_tips.md
+++ b/doc/development_tips.md
@@ -1,0 +1,7 @@
+# Development tips
+
+## Searching for a custom field?
+
+- Set `JIRA_USERNAME` and `JIRA_PASSWORD` environment variables.
+- Open a local console with `bin/console`.
+- Run `JSON.parse(JobTomate::Commands::JIRA::GetFields.run.body)`.

--- a/lib/job_tomate/commands/jira/get_fields.rb
+++ b/lib/job_tomate/commands/jira/get_fields.rb
@@ -7,6 +7,16 @@ module JobTomate
   module Commands
     module JIRA
 
+      # Command to fetch issue fields from JIRA. This is useful
+      # to find the identifier to use in code for a given custom
+      # field.
+      #
+      # How to use?
+      #
+      #    ENV["JIRA_USERNAME"] = <some jira username>
+      #    ENV["JIRA_PASSWORD"] = <the user's password>
+      #    JSON.parse(JobTomate::Commands::JIRA::GetFields.run().body)
+      #
       class GetFields
         extend ServicePattern
 

--- a/lib/job_tomate/commands/jira/get_fields.rb
+++ b/lib/job_tomate/commands/jira/get_fields.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "job_tomate/commands/jira/support/client"
+require "support/service_pattern"
+
+module JobTomate
+  module Commands
+    module JIRA
+
+      class GetFields
+        extend ServicePattern
+
+        API_USERNAME = ENV["JIRA_USERNAME"]
+        API_PASSWORD = ENV["JIRA_PASSWORD"]
+
+        def self.run
+          JobTomate::Commands::JIRA::Client.exec_request_base(
+            :get, "/field",
+            API_USERNAME, API_PASSWORD,
+            {} # body
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This enables getting fields from JIRA to identify the identifiers
of custom fields.

See `doc/development_tips.md` for how to use it.

Fixes #63 